### PR TITLE
	modified:   package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,16 +45,16 @@
     "wavefont": "^1.2.1"
   },
   "optionalDependencies": {
-    "audio-sink": "^1.0.2",
-    "speaker": "^0.3.0"
+    "audio-sink": "^1.1.6",
+    "speaker": "^0.5.1"
   },
   "dependencies": {
-    "audio-through": "^2.2.3",
-    "inherits": "^2.0.1",
-    "is-audio-buffer": "^1.0.1",
+    "audio-through": "^4.0.1",
+    "inherits": "^2.0.4",
+    "is-audio-buffer": "^1.1.0",
     "object-assign": "^4.1.1",
-    "pcm-util": "^2.1.0",
-    "pull-stream": "^3.4.5",
+    "pcm-util": "^3.0.0",
+    "pull-stream": "^3.6.14",
     "web-audio-stream": "^3.0.1"
   }
 }


### PR DESCRIPTION
just bumped up upstream packages to their current values
now npm install is OK

I see this project has several other PR
which have been ignored ... is anyone behind the wheel  ?

prior to me just doing a bump to upsteam packages the `npm install` had been erroring out 
here is that output   (  these errors are all fixed in this PR )

<details>
<summary>
../src/binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Open(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/binding.cc:30:38: error: no matching function for call to ‘v8::Value::Int32Value()’
   30 |   ao->channels = info[1]->Int32Value(); /* channels */
      |                                      ^
In file included from /home/pie/.cache/node-gyp/12.14.0/include/node/node.h:63,

</summary>

```
pie@peach ~/src/github.com/audiojs/audio-speaker $ npm install 
npm WARN deprecated tst@1.3.2: Please use tape/ava/jest/mocha instead.
npm WARN deprecated circular-json@0.3.3: CircularJSON is in maintenance only, flatted is its successor.
npm WARN deprecated json3@3.3.0: Please use the native JSON object instead of JSON 3

> speaker@0.3.1 install /home/pie/src/github.com/audiojs/audio-speaker/node_modules/speaker
> node-gyp rebuild

make: Entering directory '/home/pie/src/github.com/audiojs/audio-speaker/node_modules/speaker/build'
  CC(target) Release/obj.target/output/deps/mpg123/src/output/alsa.o
../deps/mpg123/src/output/alsa.c: In function ‘initialize_device’:
../deps/mpg123/src/output/alsa.c:78:16: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
   78 |  for (i = 0; i < NUM_FORMATS; ++i) {
      |                ^
../deps/mpg123/src/output/alsa.c: In function ‘get_formats_alsa’:
../deps/mpg123/src/output/alsa.c:201:16: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long unsigned int’ [-Wsign-compare]
  201 |  for (i = 0; i < NUM_FORMATS; ++i) {
      |                ^
  AR(target) Release/obj.target/deps/mpg123/liboutput.a
  COPY Release/liboutput.a
  CXX(target) Release/obj.target/binding/src/binding.o
In file included from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
../../nan/nan.h: In function ‘void Nan::AsyncQueueWorker(Nan::AsyncWorker*)’:
../../nan/nan.h:2298:62: warning: cast between incompatible function types from ‘void (*)(uv_work_t*)’ {aka ‘void (*)(uv_work_s*)’} to ‘uv_after_work_cb’ {aka ‘void (*)(uv_work_s*, int)’} [-Wcast-function-type]
 2298 |     , reinterpret_cast<uv_after_work_cb>(AsyncExecuteComplete)
      |                                                              ^
../src/binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Open(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/binding.cc:30:38: error: no matching function for call to ‘v8::Value::Int32Value()’
   30 |   ao->channels = info[1]->Int32Value(); /* channels */
      |                                      ^
In file included from /home/pie/.cache/node-gyp/12.14.0/include/node/node.h:63,
                 from ../../nan/nan.h:54,
                 from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note: candidate: ‘v8::Maybe<int> v8::Value::Int32Value(v8::Local<v8::Context>) const’
 2613 |   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
      |                                        ^~~~~~~~~~
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note:   candidate expects 1 argument, 0 provided
../src/binding.cc:31:34: error: no matching function for call to ‘v8::Value::Int32Value()’
   31 |   ao->rate = info[2]->Int32Value(); /* sample rate */
      |                                  ^
In file included from /home/pie/.cache/node-gyp/12.14.0/include/node/node.h:63,
                 from ../../nan/nan.h:54,
                 from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note: candidate: ‘v8::Maybe<int> v8::Value::Int32Value(v8::Local<v8::Context>) const’
 2613 |   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
      |                                        ^~~~~~~~~~
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note:   candidate expects 1 argument, 0 provided
../src/binding.cc:32:36: error: no matching function for call to ‘v8::Value::Int32Value()’
   32 |   ao->format = info[3]->Int32Value(); /* MPG123_ENC_* format */
      |                                    ^
In file included from /home/pie/.cache/node-gyp/12.14.0/include/node/node.h:63,
                 from ../../nan/nan.h:54,
                 from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note: candidate: ‘v8::Maybe<int> v8::Value::Int32Value(v8::Local<v8::Context>) const’
 2613 |   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
      |                                        ^~~~~~~~~~
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note:   candidate expects 1 argument, 0 provided
../src/binding.cc: In function ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Write(Nan::NAN_METHOD_ARGS_TYPE)’:
../src/binding.cc:51:33: error: no matching function for call to ‘v8::Value::Int32Value()’
   51 |   int len = info[2]->Int32Value();
      |                                 ^
In file included from /home/pie/.cache/node-gyp/12.14.0/include/node/node.h:63,
                 from ../../nan/nan.h:54,
                 from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note: candidate: ‘v8::Maybe<int> v8::Value::Int32Value(v8::Local<v8::Context>) const’
 2613 |   V8_WARN_UNUSED_RESULT Maybe<int32_t> Int32Value(Local<Context> context) const;
      |                                        ^~~~~~~~~~
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:2613:40: note:   candidate expects 1 argument, 0 provided
../src/binding.cc:62:78: warning: cast between incompatible function types from ‘void (*)(uv_work_t*)’ {aka ‘void (*)(uv_work_s*)’} to ‘uv_after_work_cb’ {aka ‘void (*)(uv_work_s*, int)’} [-Wcast-function-type]
   62 |   uv_queue_work(uv_default_loop(), &req->req, write_async, (uv_after_work_cb)write_after);
      |                                                                              ^~~~~~~~~~~
../src/binding.cc: In function ‘void {anonymous}::write_after(uv_work_t*)’:
../src/binding.cc:80:31: warning: ‘v8::Local<v8::Value> Nan::Callback::Call(int, v8::Local<v8::Value>*) const’ is deprecated [-Wdeprecated-declarations]
   80 |   wreq->callback->Call(1, argv);
      |                               ^
In file included from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
../../nan/nan.h:1740:3: note: declared here
 1740 |   Call(int argc, v8::Local<v8::Value> argv[]) const {
      |   ^~~~
../src/binding.cc: At global scope:
../src/binding.cc:104:17: error: variable or field ‘Initialize’ declared void
  104 | void Initialize(Handle<Object> target) {
      |                 ^~~~~~
../src/binding.cc:104:17: error: ‘Handle’ was not declared in this scope
../src/binding.cc:104:30: error: expected primary-expression before ‘>’ token
  104 | void Initialize(Handle<Object> target) {
      |                              ^
../src/binding.cc:104:32: error: ‘target’ was not declared in this scope
  104 | void Initialize(Handle<Object> target) {
      |                                ^~~~~~
In file included from ../../nan/nan.h:54,
                 from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
../src/binding.cc:155:22: error: ‘Initialize’ was not declared in this scope
  155 | NODE_MODULE(binding, Initialize)
      |                      ^~~~~~~~~~
/home/pie/.cache/node-gyp/12.14.0/include/node/node.h:566:36: note: in definition of macro ‘NODE_MODULE_X’
  566 |       (node::addon_register_func) (regfunc),                          \
      |                                    ^~~~~~~
../src/binding.cc:155:1: note: in expansion of macro ‘NODE_MODULE’
  155 | NODE_MODULE(binding, Initialize)
      | ^~~~~~~~~~~
In file included from /home/pie/.cache/node-gyp/12.14.0/include/node/node.h:63,
                 from ../../nan/nan.h:54,
                 from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h: In instantiation of ‘void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = node::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)]’:
/home/pie/.cache/node-gyp/12.14.0/include/node/node_object_wrap.h:84:78:   required from here
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:10004:16: warning: cast between incompatible function types from ‘v8::WeakCallbackInfo<node::ObjectWrap>::Callback’ {aka ‘void (*)(const v8::WeakCallbackInfo<node::ObjectWrap>&)’} to ‘Callback’ {aka ‘void (*)(const v8::WeakCallbackInfo<void>&)’} [-Wcast-function-type]
10004 |                reinterpret_cast<Callback>(callback), type);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h: In instantiation of ‘void v8::PersistentBase<T>::SetWeak(P*, typename v8::WeakCallbackInfo<P>::Callback, v8::WeakCallbackType) [with P = Nan::ObjectWrap; T = v8::Object; typename v8::WeakCallbackInfo<P>::Callback = void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)]’:
../../nan/nan_object_wrap.h:65:61:   required from here
/home/pie/.cache/node-gyp/12.14.0/include/node/v8.h:10004:16: warning: cast between incompatible function types from ‘v8::WeakCallbackInfo<Nan::ObjectWrap>::Callback’ {aka ‘void (*)(const v8::WeakCallbackInfo<Nan::ObjectWrap>&)’} to ‘Callback’ {aka ‘void (*)(const v8::WeakCallbackInfo<void>&)’} [-Wcast-function-type]
In file included from ../src/node_pointer.h:6,
                 from ../src/binding.cc:5:
../src/binding.cc:93:12: warning: ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Close(Nan::NAN_METHOD_ARGS_TYPE)’ defined but not used [-Wunused-function]
   93 | NAN_METHOD(Close) {
      |            ^~~~~
../../nan/nan.h:1566:33: note: in definition of macro ‘NAN_METHOD’
 1566 |     Nan::NAN_METHOD_RETURN_TYPE name(Nan::NAN_METHOD_ARGS_TYPE info)
      |                                 ^~~~
../src/binding.cc:85:12: warning: ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Flush(Nan::NAN_METHOD_ARGS_TYPE)’ defined but not used [-Wunused-function]
   85 | NAN_METHOD(Flush) {
      |            ^~~~~
../../nan/nan.h:1566:33: note: in definition of macro ‘NAN_METHOD’
 1566 |     Nan::NAN_METHOD_RETURN_TYPE name(Nan::NAN_METHOD_ARGS_TYPE info)
      |                                 ^~~~
../src/binding.cc:47:12: warning: ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Write(Nan::NAN_METHOD_ARGS_TYPE)’ defined but not used [-Wunused-function]
   47 | NAN_METHOD(Write) {
      |            ^~~~~
../../nan/nan.h:1566:33: note: in definition of macro ‘NAN_METHOD’
 1566 |     Nan::NAN_METHOD_RETURN_TYPE name(Nan::NAN_METHOD_ARGS_TYPE info)
      |                                 ^~~~
../src/binding.cc:24:12: warning: ‘Nan::NAN_METHOD_RETURN_TYPE {anonymous}::Open(Nan::NAN_METHOD_ARGS_TYPE)’ defined but not used [-Wunused-function]
   24 | NAN_METHOD(Open) {
      |            ^~~~
../../nan/nan.h:1566:33: note: in definition of macro ‘NAN_METHOD’
 1566 |     Nan::NAN_METHOD_RETURN_TYPE name(Nan::NAN_METHOD_ARGS_TYPE info)
      |                                 ^~~~
make: *** [binding.target.mk:120: Release/obj.target/binding/src/binding.o] Error 1
make: Leaving directory '/home/pie/src/github.com/audiojs/audio-speaker/node_modules/speaker/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/pie/src/node-v12.14.0-linux-x64/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:194:23)
gyp ERR! stack     at ChildProcess.emit (events.js:210:5)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)
gyp ERR! System Linux 5.3.0-25-generic
gyp ERR! command "/home/pie/src/node-v12.14.0-linux-x64/bin/node" "/home/pie/src/node-v12.14.0-linux-x64/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /home/pie/src/github.com/audiojs/audio-speaker/node_modules/speaker
gyp ERR! node -v v12.14.0
gyp ERR! node-gyp -v v5.0.5
gyp ERR! not ok 
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN The package pcm-util is included as both a dev and production dependency.
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: speaker@0.3.1 (node_modules/speaker):
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: speaker@0.3.1 install: `node-gyp rebuild`
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: Exit status 1

added 202 packages from 183 contributors and audited 812 packages in 5.181s

17 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities




```
</details>
