### PR TITLE
Bumped speaker version in order to allow installs in newer node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "optionalDependencies": {
     "audio-sink": "^1.0.2",
-    "speaker": "^0.3.0"
+    "speaker": "^0.5.3"
   },
   "dependencies": {
     "audio-through": "^2.2.3",


### PR DESCRIPTION
Hi there,

I was trying to install the library in a project that is being developed using node 14.15 and I got some problems when compiling the speaker dependency and I've found that the problem is that the version specified in the package.json file is outdated, so I want to bump the version to make the package installation work correctly. 

The version specified in the package only works on node 10 and old releases.