### PR TITLE
Add optional dependency for speaker-darwin-arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "optionalDependencies": {
     "@audio/speaker-darwin-x64": ">=2.0.0",
+    "@audio/speaker-darwin-arm64": ">=2.0.0",
     "@audio/speaker-linux-arm64": ">=2.0.0",
     "@audio/speaker-linux-x64": ">=2.0.0",
     "@audio/speaker-win32-x64": ">=2.0.0"


### PR DESCRIPTION
audio-speaker did not declare @audio/speaker-darwin-arm64 as an optional dependency. On those machines the miniaudio backend could not require() the platform package, so playback fell back to the process backend (often unavailable on macOS) and then the null backend, which keeps timing but produces no audible output.

This change adds @audio/speaker-darwin-arm64 alongside the existing @audio/speaker-* optional packages so installs on Apple Silicon pull the correct prebuilt native addon.


As a temporary fix for anyone with the same problem, I extended the config on my end with pnpm config
```
  "pnpm": {
    "packageExtensions": {
      "audio-speaker@*": {
        "optionalDependencies": {
          "@audio/speaker-darwin-arm64": ">=2.0.0"
        }
      }
    }
  },
```